### PR TITLE
feat: remove printing redundant information

### DIFF
--- a/run-new-idgun.py
+++ b/run-new-idgun.py
@@ -22,8 +22,8 @@ for gun_name in sorted(list(guns.keys())):
         # should update gun
         if len(results) == 1:
             (gun_category, bounding_box_size, pattern), = results
-            print(gun_name, gun_category, lt4.pattern(pattern).getrect())
+            # print(gun_name, gun_category, lt4.pattern(pattern).getrect())
         # should update gun and guntrue
         elif len(results) == 2:
             (gun_category, bounding_box_size, pattern), (guntrue_category, _, _) = results
-            print(gun_name, gun_category, lt4.pattern(pattern).getrect())
+            # print(gun_name, gun_category, lt4.pattern(pattern).getrect())

--- a/run-old-idgun.py
+++ b/run-old-idgun.py
@@ -22,8 +22,8 @@ for gun_name in sorted(list(guns.keys())):
         # should update gun
         if len(results) == 1:
             (gun_category, bounding_box_size, pattern), = results
-            print(gun_name, gun_category, lt4.pattern(pattern).getrect())
+            # print(gun_name, gun_category, lt4.pattern(pattern).getrect())
         # should update gun and guntrue
         elif len(results) == 2:
             (gun_category, bounding_box_size, pattern), (guntrue_category, _, _) = results
-            print(gun_name, gun_category, lt4.pattern(pattern).getrect())
+            # print(gun_name, gun_category, lt4.pattern(pattern).getrect())


### PR DESCRIPTION
When I was writing run-{old,new}-idgun.py, I thought idgun.py did not log anything and added my own logs to check bounding boxes. It turns out that idgun.py logs bounding box sizes, so the logs I added was redundant.